### PR TITLE
fix(deps): bump brace-expansion and js-yaml to resolve 6 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1879,10 +1879,20 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2806,16 +2816,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3334,9 +3344,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6285,9 +6295,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
`npm audit fix` の結果、`package-lock.json` のみの変更です。

## 解消される Dependabot アラート (6件すべて)

| Alert | Package | 脆弱範囲 | 変更後 | Advisory |
|---|---|---|---|---|
| #62 | brace-expansion | `< 1.1.16` | 1.1.12 → **1.1.16** | GHSA-3jxr-9vmj-r5cp |
| #59 | brace-expansion | `>= 3.0.0, < 5.0.7` | 5.0.6 → **5.0.8** | GHSA-3jxr-9vmj-r5cp |
| #61 | js-yaml | `>= 4.0.0, < 4.3.0` | 4.1.1 → **4.3.0** | GHSA-52cp-r559-cp3m |
| #60 | js-yaml | `>= 3.0.0, < 3.15.0` | 3.14.2 → **3.15.0** | GHSA-52cp-r559-cp3m |
| #58 | js-yaml | `< 3.15.0` | 3.14.2 → **3.15.0** | GHSA-h67p-54hq-rp68 |
| #57 | js-yaml | `>= 4.0.0, <= 4.1.1` | 4.1.1 → **4.3.0** | GHSA-h67p-54hq-rp68 |

いずれも devDependencies の推移的依存で、DoS 系の advisory です。
`brace-expansion` と `js-yaml` はそれぞれ依存ツリー内に異なるメジャーで2箇所存在するため、片方だけの更新では半分のアラートが残ります。

## `--force` を使っていない理由

`package.json` の semver 範囲内でオープンな6件すべてが解消できるため、lockfile のみの変更で済んでいます。

残る `brace-expansion` GHSA-mh99-v99m-4gvg (alert #63) は `npm audit fix --force` = `eslint@10` への破壊的アップグレードが必要ですが、このアラートは GitHub 側で既に `auto_dismissed` になっているため対象外としました。

## 動作確認

ローカル (Node v24.18.0 / npm 11.16.0) で以下を確認済みです。

- `npm test` (pretest の `prettier --check` + `eslint` を含む) → 2 passed
- `npm run test:mjs` → 2 passed
- `npm ci` でクリーンインストールが再現し、lockfile が追加変更されないこと
- 更新後4パッケージの `integrity` ハッシュが npm レジストリの実体と一致すること

`brace-expansion` 5.0.8 は `engines` から Node 18 が外れますが (`18 || 20 || >=22` → `20 || >=22`)、CI マトリクスは Node 22.x / 24.x のため影響ありません。
